### PR TITLE
[CHORES] 코드상은 변화  없음, 분당데이터 처리요청만 클라리언트에서 진행하고 메인로직은 로컬 서버에서 진행

### DIFF
--- a/src/app/(browse)/live/_components/video.tsx
+++ b/src/app/(browse)/live/_components/video.tsx
@@ -24,6 +24,7 @@ import Offline_Video from "./offline_video";
 import Loading_Video from "./loading_video";
 import LiveVideo from "./live_video";
 import { Button } from "@/components/ui/button";
+import { useSocketStore } from "@/store/socket_store";
 
 interface VideoProps {
   host_name: string | undefined;
@@ -32,11 +33,11 @@ interface VideoProps {
   className?: string;
 }
 const Video = ({ host_name, host_identity, token }: VideoProps) => {
+  const { socket, connect_socket } = useSocketStore();
   const participants = useParticipants();
   const connection_state = useConnectionState();
   const host_participant = useRemoteParticipant(host_identity);
-
-  const [total_viewer, set_total_viewer] = useState<number>();
+  const [total_viewer, set_total_viewer] = useState<number>(0);
   useEffect(() => {}, [connection_state, host_participant, participants]);
 
   const tracks = useTracks([
@@ -47,8 +48,11 @@ const Video = ({ host_name, host_identity, token }: VideoProps) => {
   );
   useEffect(() => {
     set_total_viewer(participants.length - 1);
-  }, []);
+    const viewer_info_per_minute = setInterval(() => {}, 6000);
+  }, [host_participant, participants]);
 
+  console.log("현재 룸의 정보알아보기", participants);
+  console.log("현재 호스트는 누구 ? ", host_participant);
   let content;
   //서버와 연결은 되었는데 아직 room이 연결되지 않았을때
   if (connection_state !== ConnectionState.Connected) {

--- a/src/app/(browse)/live/_components/video.tsx
+++ b/src/app/(browse)/live/_components/video.tsx
@@ -38,7 +38,6 @@ const Video = ({ host_name, host_identity, token }: VideoProps) => {
   const connection_state = useConnectionState();
   const host_participant = useRemoteParticipant(host_identity);
   const [total_viewer, set_total_viewer] = useState<number>(0);
-  useEffect(() => {}, [connection_state, host_participant, participants]);
 
   const tracks = useTracks([
     Track.Source.Camera,
@@ -46,12 +45,26 @@ const Video = ({ host_name, host_identity, token }: VideoProps) => {
   ]).filter(
     (track) => track.participant.identity === host_participant?.identity
   );
-  useEffect(() => {
-    set_total_viewer(participants.length - 1);
-    const viewer_info_per_minute = setInterval(() => {}, 6000);
-  }, [host_participant, participants]);
+  const remote_participants = participants.filter(
+    (participant) => participant instanceof RemoteParticipant
+  );
+  const all_remote_participant = remote_participants.map(
+    (participant) => participant.identity
+  );
 
-  console.log("현재 룸의 정보알아보기", participants);
+  // 호스트를 제외한 방에 참가한 모든 유저
+  const remote_participant_except_host = all_remote_participant.filter(
+    (participant) => participant !== host_identity
+  );
+  useEffect(() => {
+    if (!socket) {
+      connect_socket();
+      console.log("소켓에 연결되었습니다.");
+    }
+    set_total_viewer(participants.length - 1);
+    socket?.emit("user_in_out", remote_participant_except_host);
+  }, [participants]);
+
   console.log("현재 호스트는 누구 ? ", host_participant);
   let content;
   //서버와 연결은 되었는데 아직 room이 연결되지 않았을때
@@ -91,21 +104,11 @@ const Video = ({ host_name, host_identity, token }: VideoProps) => {
       </div>
     );
   }
-  // if (true) {
-  //   return (<div>ddddzzzd
-  //     <LiveVideo participant={host_participant}
-  //   </div>)
-  // }
 
-  let peak_viewers_minute = 0;
-  let peak_viewers_hour = 0;
-
-  // Room.on("participantConnected");
   return (
     <div className="aspect-video object-contain group relative w-full">
       {content}
       <div>현재 모든 시청자 수 {total_viewer}</div>
-      {/* <LiveVideo participant={host_participant} /> */}
     </div>
   );
 };


### PR DESCRIPTION
- 유저의 입/출에 대한 사인만 로컬 서버로 보내고, 관련 로직은 서버에서 처리
- 웹훅 관련 로직도 서버에서 처리하도록 금요일까지 처리할 것
- FIGMA를 이용하여 스트리밍 페이지 정리