### PR TITLE
[CHORES] 실행시 한번만 생성되는 Redis client와 subscriber 생성 중

### DIFF
--- a/local_server/src/services/redis_subscriber.js
+++ b/local_server/src/services/redis_subscriber.js
@@ -1,0 +1,35 @@
+const {subscriber,channel}=require('../config/redis')
+
+
+
+const initSubscriber=(io)=>{
+   console.log("Redis 구독이 초기 실행중입니다.✅")
+
+   subscriber.on(`message`,(channel,message)=>{
+
+       try {
+        const parsed_msg=JSON.parse(message)
+        console.log(`채널로부터 메세지를 받음:`,parsed_msg)
+       
+        // if(channel)
+      } catch (error) {
+       console.error(`구독한 Redis의 메세지를 받던 중 오류 발생!🚀`)
+      }
+   })
+   
+   subscriber.subscribe(channel,(error,count)=>{
+    if(error){
+        console.log(`Redis 채널을 구독하는데 실패하였습니다.😢`, error)
+        return
+    }
+    console.log(`성공적으로 구독을 성공하였습니다.✨`)
+   })
+
+   const sacntion_user=(io)=>{
+    const {user_id,streamer_id,reason,duration}=payload
+    const streamer=`streamer-${streamer_id}`
+    const user=`user-${user_id}`
+
+    if(type===`sanction`)
+   }
+}


### PR DESCRIPTION
- redis client와 subscriber 생성 
- 제재 시 각각의 docker안 로컬 서버가 "제제받은 유저의 유무 확인"
- "제재 받은 유저"가 있으면 해당 유저와 스트리머에게 제재 관련 정보 전송