### PR TITLE
BE/BUILD(nginx,docker,redis) docker 컨테이이너 작동을 위한 환경설정-> docker파일 실행 오…

### DIFF
--- a/local_server/docker-compose.yml
+++ b/local_server/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # 1. 'redis-server' 라는 이름의 서비스 (NPC 상점 주인)
   redis-server:
     image: "redis:latest" # Redis 공식 최신 버전 이미지를 사용
-    container_name: my-chat-redis # 컨테이너에 별명 붙여주기
+    : container_name:app_normal_redis # 컨테이너에 별명 붙여주기
     ports:
       - "6379:6379" # 내 PC의 6379 포트와 컨테이너의 6379 포트를 연결
     networks:
@@ -20,8 +20,8 @@ services:
       - "3000:3000"
     environment:
       - REDIS_URL=redis://redis-server:6379
-      - SUPABASE_URL=${SUPABASE_URL}
-      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
+      # - SUPABASE_URL=${SUPABASE_URL}
+      # - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
     depends_on:
       - redis-server # 'app'은 'redis-server'가 먼저 실행된 후에 실행되어야 함
     networks:

--- a/local_server/nginx.conf
+++ b/local_server/nginx.conf
@@ -1,8 +1,9 @@
 events{}
 
 http{
-    upstream node_servers{
-
+    # 부하를 분산할 서버들의 그룹 정의 
+    upstream app_normal_node_servers{
+    # Docker compose가 만들어줄 Node.js 컨테이너들의 서비스 이름과 포트 정의 
 
         # 고정 세션의 기능을 하는
         # ip_hash 
@@ -12,13 +13,17 @@ http{
         server app_normal2:4000
     }
 
-    location / {
-        proxy_pass http://node_servers\
+    server{
+        listen:3001
+        location /{
+             proxy_pass http://my-node-app;
 
-
-           proxy_http_version 1.1
-            proxy_set_header Upgrade $http_upgrade;
-              proxy_set_header Connection "upgrade";
-               proxy_set_header Host $host;
+            # 클라이언트의 실제 IP, 프로토콜 등의 정보->BE로 전달하기 위한 헤더설정
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
     }
+   
 }


### PR DESCRIPTION
- BE/ nginx,docker,redis 파일 환경 설정 -> 오류 발생으로 실행 X
- nginx 의 key 값 오류 발생  
- 각 페이지 혹은 기능에 맞는 브랜치로 다음 커밋부터 분리 요구됨
