### PR TITLE
[DEBUG] 새로고침시 socket 연결 해제 오류 수정 중

### DIFF
--- a/local_server/src/socket/copilot-socket.js
+++ b/local_server/src/socket/copilot-socket.js
@@ -1,8 +1,8 @@
 let namespace = null;
 export const copilotSocket = (socket, copilotRoom) => {
   const roomName = socket.data.roomName;
-  console.log("copilot-socket 내에서 namespaceRoom 확인", copilotRoom);
   namespace = copilotRoom;
+  console.log("코파일럿룸 네임스페이스 확인하기 , ", namespace);
   socket.on("copilot-connected", () => {
     socket.join(`copilot:${roomName}`);
   });

--- a/local_server/src/socket/namespace/copilot.js
+++ b/local_server/src/socket/namespace/copilot.js
@@ -3,11 +3,9 @@ import { copilotSocket } from "../copilot-socket.js";
 
 export const copilotNamespace = (io) => {
   const copilotRoom = io.of("/copilot");
-
   copilotRoom.use(authorizeHost);
-
   copilotRoom.on("connection", (socket) => {
-    console.log(`copilot-socket 연결 완료 (host: ${socket.data.roomName}) ✅`);
+    console.log("authorizeHost 에서 next 실행후 , connection ");
     copilotSocket(socket, copilotRoom);
   });
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  reactStrictMode: false,
+};
 
 export default nextConfig;

--- a/src/app/(browse)/studio/live/[id]/page.tsx
+++ b/src/app/(browse)/studio/live/[id]/page.tsx
@@ -45,6 +45,12 @@ const StudioLivePage = ({ params }: { params: { id: string } }) => {
 
     copilotSocket.emit("copilot-connected");
 
+    // 재연결(서버 재시작 등) 시 room에서 빠지므로 다시 join 필요
+    const rejoinCopilotRoom = () => {
+      copilotSocket.emit("copilot-connected");
+    };
+    copilotSocket.io.on("reconnect", rejoinCopilotRoom);
+
     copilotSocket.on("connect_error", (err) => {
       console.error("[코파일럿 소켓] 연결 실패:", err.message);
     });
@@ -56,6 +62,7 @@ const StudioLivePage = ({ params }: { params: { id: string } }) => {
     });
 
     return () => {
+      copilotSocket.io.off("reconnect", rejoinCopilotRoom);
       copilotSocket.disconnect();
       if (timerRef.current) clearTimeout(timerRef.current);
     };


### PR DESCRIPTION
## DEBUG 
- studio/live 페이지를 나갔다 들어오면 정상적인 socket 연결 완료
- 새로 고침 시 cleanup이 제대로 되지 않은 채로 socket 의 재연결 시도로 인한 socket 재연결 오류라고 추측됨


## TODO
- 새로고침시 window.addEventListener("beforeunload")를 사용하여 socket의 연결을 명시적으로 해제할것 